### PR TITLE
Botany balancing, XRF description botany hints, and mutation controller

### DIFF
--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -271,8 +271,8 @@
 		production_time_counter = 0
 		chem_add_counter = 0
 		metabolism_adjust = 0
-		for(var/j = 1; j<=length(mutation_controller); j++)
-			var/mut_name = mutation_controller[j]
+		for(var/i in 1 to length(mutation_controller))
+			var/mut_name = mutation_controller[i]
 			if(mutation_controller[mut_name] > -3)
 				mutation_controller[mut_name] = 0
 
@@ -297,8 +297,8 @@
 	production_time_counter = 0
 	chem_add_counter = 0
 	metabolism_adjust = 0
-	for(var/j = 1; j<=length(mutation_controller); j++)
-		var/mut_name = mutation_controller[j]
+	for(var/i in 1 to length(mutation_controller))
+		var/mut_name = mutation_controller[i]
 		if(mutation_controller[mut_name] > -3)
 			mutation_controller[mut_name] = 0
 
@@ -407,8 +407,6 @@
 	pestlevel =   max(0,min(pestlevel,10))
 	weedlevel =   max(0,min(weedlevel,10))
 	toxins =  max(0,min(toxins,10))
-	//Adjust the time between plant cycles Min -140
-	metabolism_adjust = 0
 
 	//Ensures increased nutrient and water consumption as yield_mod increases
 	if(yield_mod>20)

--- a/code/modules/hydroponics/hydro_tray.dm
+++ b/code/modules/hydroponics/hydro_tray.dm
@@ -55,7 +55,25 @@
 	var/metabolism_adjust = 0
 	///if the plant is going to harvest itself once its ready
 	var/autoharvest = FALSE
-
+	///Initialize() 13 potential slots to block corresponding to seed/proc/mutate and hydroponics/proc/mutate
+	var/list/mutation_controller = list(
+		"Plant Cancer" = 0,
+		"Gluttony" = 0,
+		"Endurance" = 0,
+		"Light Tolerance" = 0,
+		"Toxin Tolerance" = 0,
+		"Weed Tolerance" = 0,
+		"Production" = 0,
+		"Lifespan" = 0,
+		"Potency" = 0,
+		"Maturity" = 0,
+		"Bioluminecence" = 0,
+		"Flowers" = 0,
+		"New Chems" = 0,
+		"New Chems2" = 0,
+		"New Chems3" = 0,
+		"Mutate Species" = 0,
+		)
 
 
 	// Reagent information for process(), consider moving this to a controller along
@@ -247,14 +265,16 @@
 		age = 0
 		sampled = 0
 		mutation_mod = 0
-		///resets these counters when the plant is harvested and removed from tray
+		//resets these counters when the plant is harvested and removed from tray
 		potency_counter = 0
 		repeat_harvest_counter = 0
 		production_time_counter = 0
 		chem_add_counter = 0
-
-
-
+		metabolism_adjust = 0
+		for(var/j = 1; j<=length(mutation_controller); j++)
+			var/mut_name = mutation_controller[j]
+			if(mutation_controller[mut_name] > -3)
+				mutation_controller[mut_name] = 0
 
 	check_level_sanity()
 	update_icon()
@@ -271,13 +291,16 @@
 	age = 0
 	yield_mod = 0
 	mutation_mod = 0
-	///resets these counters when the plant is harvested and removed from tray
+	//resets these counters when the plant is harvested and removed from tray
 	potency_counter = 0
 	repeat_harvest_counter = 0
 	production_time_counter = 0
 	chem_add_counter = 0
-
-
+	metabolism_adjust = 0
+	for(var/j = 1; j<=length(mutation_controller); j++)
+		var/mut_name = mutation_controller[j]
+		if(mutation_controller[mut_name] > -3)
+			mutation_controller[mut_name] = 0
 
 
 	to_chat(user, SPAN_NOTICE("You remove the dead plant from [src]."))
@@ -357,8 +380,8 @@
 	if(!seed)
 		return
 
-	// Check if we should even bother working on the current seed datum.
-	if(LAZYLEN(seed.mutants) && severity > 1)
+	// Check if we should even bother working on the current seed datum. mutation_controller
+	if((LAZYLEN(seed.mutants) && severity > 1 && mutation_controller["Mutate Species"] == 0) || mutation_controller["Mutate Species"] > 0)
 		mutate_species()
 		return
 
@@ -367,7 +390,7 @@
 	// harvested yet and it's safe to assume it's restricted to this tray.
 	if(!isnull(GLOB.seed_types[seed.name]))
 		seed = seed.diverge()
-	seed.mutate(severity ,get_turf(src), mutation_level)
+	seed.mutate(severity ,get_turf(src), src)
 	return
 
 /obj/structure/machinery/portable_atmospherics/hydroponics/proc/check_level_sanity()
@@ -384,21 +407,24 @@
 	pestlevel =   max(0,min(pestlevel,10))
 	weedlevel =   max(0,min(weedlevel,10))
 	toxins =  max(0,min(toxins,10))
+	//Adjust the time between plant cycles Min -140
+	metabolism_adjust = 0
 
+	//Ensures increased nutrient and water consumption as yield_mod increases
 	if(yield_mod>20)
 		seed = seed.diverge()
 		if(yield_mod>70)
-			seed.nutrient_consumption = max(7,seed.nutrient_consumption)
-			seed.water_consumption = max(25,seed.water_consumption)
+			seed.nutrient_consumption = max(3,seed.nutrient_consumption)
+			seed.water_consumption = max(10,seed.water_consumption)
 		else if(yield_mod>50)
-			seed.nutrient_consumption = max(5,seed.nutrient_consumption)
-			seed.water_consumption = max(20,seed.water_consumption)
+			seed.nutrient_consumption = max(2.5,seed.nutrient_consumption)
+			seed.water_consumption = max(8,seed.water_consumption)
 		else if(yield_mod>30)
 			seed.nutrient_consumption = max(2,seed.nutrient_consumption)
-			seed.water_consumption = max(14,seed.water_consumption)
+			seed.water_consumption = max(6,seed.water_consumption)
 		else if(yield_mod>20)
 			seed.nutrient_consumption = max(1,seed.nutrient_consumption)
-			seed.water_consumption = max(6,seed.water_consumption)
+			seed.water_consumption = max(3,seed.water_consumption)
 
 /obj/structure/machinery/portable_atmospherics/hydroponics/proc/mutate_species()
 

--- a/code/modules/hydroponics/seed_datums.dm
+++ b/code/modules/hydroponics/seed_datums.dm
@@ -323,16 +323,15 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 	var/list/allowed_mutations[]
 
 	//Generates list of what mutation outcomes are allowed after considering mutation cancel and mutation enable effects
-	for(var/c=1; c<length(mutation_controller); c++)
-		var/mut_name = mutation_controller[c]
+	for(var/i in 1 to length(mutation_controller)-1)
+		var/mut_name = mutation_controller[i]
 		if(mutation_controller[mut_name] > 0)
-			super_allowed_mutations += list(c)
+			super_allowed_mutations += list(i)
 			mutation_enable_check = TRUE
 		if((mutation_controller[mut_name] == 0 || mutation_controller[mut_name] == -1) && mutation_enable_check == FALSE)
+			allowed_mutations += list(i)
 			if(mutation_controller[mut_name] == -1)
-				allowed_mutations += list(-c)
-				return
-			allowed_mutations += list(c)
+				allowed_mutations[i] = -i
 	if(mutation_enable_check == TRUE)
 		allowed_mutations = super_allowed_mutations
 
@@ -408,8 +407,8 @@ GLOBAL_LIST_EMPTY(gene_tag_masks)   // Gene obfuscation for delicious trial and 
 				chems += chem_to_add
 
 	//reset mutation_controller for next cycle
-	for(var/j = 1; j<=length(mutation_controller); j++)
-		var/mut_name = mutation_controller[j]
+	for(var/i in 1 to length(mutation_controller))
+		var/mut_name = mutation_controller[i]
 		if(mutation_controller[mut_name] > -3)
 			processing_tray.mutation_controller[mut_name] = 0
 	return

--- a/code/modules/reagents/chemistry_properties/prop_negative.dm
+++ b/code/modules/reagents/chemistry_properties/prop_negative.dm
@@ -32,7 +32,7 @@
 /datum/chem_property/negative/toxic
 	name = PROPERTY_TOXIC
 	code = "TXC"
-	description = "Poisonous substance which causes harm on contact with or through absorption by organic tissues, resulting in bad health or severe illness."
+	description = "Poisonous substance which causes harm on contact with or through absorption by organic tissues, resulting in bad health, severe illness, or plant death."
 	rarity = PROPERTY_COMMON
 	starter = TRUE
 	value = -1
@@ -77,7 +77,7 @@
 /datum/chem_property/negative/corrosive
 	name = PROPERTY_CORROSIVE
 	code = "CRS"
-	description = "Damages or destroys other substances on contact through a chemical reaction. Causes chemical burns on contact with living tissue."
+	description = "Damages or destroys other substances on contact through a chemical reaction. Causes chemical burns on contact with living tissue. Reduces pest and weed populations."
 	rarity = PROPERTY_COMMON
 	starter = TRUE
 	value = 1 //has a combat use
@@ -172,7 +172,7 @@
 /datum/chem_property/negative/biocidic
 	name = PROPERTY_BIOCIDIC
 	code = "BCD"
-	description = "Ruptures cell membranes on contact, destroying most types of organic tissue."
+	description = "Ruptures cell membranes on contact, destroying most types of organic tissue. Reduces pest and weed populations."
 	rarity = PROPERTY_COMMON
 	starter = TRUE
 	value = -1
@@ -255,7 +255,7 @@
 /datum/chem_property/negative/hemorrhaging
 	name = PROPERTY_HEMORRAGING
 	code = "HMR"
-	description = "Ruptures endothelial cells making up bloodvessels, causing blood to escape from the circulatory system."
+	description = "Ruptures endothelial cells making up bloodvessels, causing blood to escape from the circulatory system. Persistant mutagen to plants."
 	rarity = PROPERTY_UNCOMMON
 	value = 2
 	cost_penalty = FALSE
@@ -300,14 +300,14 @@
 	. = ..()
 	if(!processing_tray.seed)
 		return
-	processing_tray.plant_health += -1*(potency*2)*volume
+	processing_tray.plant_health += -0.2*(potency*2)*volume
 	processing_tray.mutation_mod+= 0.2*(potency*2)*volume
 
 
 /datum/chem_property/negative/carcinogenic
 	name = PROPERTY_CARCINOGENIC
 	code = "CRG"
-	description = "Penetrates the cell nucleus causing direct damage to the deoxyribonucleic acid in cells resulting in cancer and abnormal cell proliferation. In extreme cases causing hyperactive apoptosis and potentially atrophy."
+	description = "Penetrates the cell nucleus causing direct damage to the deoxyribonucleic acid in cells resulting in cancer, abnormal cell proliferation, and mutation in plants. In extreme cases causing hyperactive apoptosis, potentially atrophy."
 	rarity = PROPERTY_COMMON
 
 /datum/chem_property/negative/carcinogenic/process(mob/living/M, potency = 1, delta_time)
@@ -331,7 +331,7 @@
 /datum/chem_property/negative/hepatotoxic
 	name = PROPERTY_HEPATOTOXIC
 	code = "HPT"
-	description = "Damages hepatocytes in the liver, resulting in liver deterioration and eventually liver failure."
+	description = "Damages hepatocytes in the liver, resulting in liver deterioration and eventually liver failure. Prevents some negative mutations in plants."
 	rarity = PROPERTY_UNCOMMON
 
 /datum/chem_property/negative/hepatotoxic/process(mob/living/M, potency = 1, delta_time)
@@ -346,10 +346,20 @@
 /datum/chem_property/negative/hepatotoxic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, TOX)
 
+//Applies mutation cancel onto hydrotray plants, negative affects like increasing consumption and lowering life
+/datum/chem_property/negative/hepatotoxic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Plant Cancer"] > potency*-2)
+		processing_tray.mutation_controller["Plant Cancer"] = potency*-2
+	if (processing_tray.mutation_controller["Gluttony"] > potency*-2)
+		processing_tray.mutation_controller["Gluttony"] = potency*-2
+
 /datum/chem_property/negative/intravenous
 	name = PROPERTY_INTRAVENOUS
 	code = "INV"
-	description = "Due to chemical composition, this chemical can only be administered intravenously. The side effect is improving absorption on the chemical, although this is less effective than natural absorption"
+	description = "Due to chemical composition, this chemical can only be administered intravenously."
 	rarity = PROPERTY_COMMON
 	category = PROPERTY_TYPE_METABOLITE
 
@@ -369,7 +379,7 @@
 /datum/chem_property/negative/nephrotoxic
 	name = PROPERTY_NEPHROTOXIC
 	code = "NPT"
-	description = "Causes deterioration and damage to podocytes in the kidney resulting in potential kidney failure."
+	description = "Causes deterioration and damage to podocytes in the kidney resulting in potential kidney failure. Prevents the tolerance to light, weeds, and toxins from mutating in plants."
 	rarity = PROPERTY_UNCOMMON
 
 /datum/chem_property/negative/nephrotoxic/process(mob/living/M, potency = 1, delta_time)
@@ -384,10 +394,22 @@
 /datum/chem_property/negative/nephrotoxic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, TOX)
 
+//Applies mutation cancel onto hydrotray plants, prevents tolerance adjustment, parasitic and carnivorus
+/datum/chem_property/negative/nephrotoxic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Light Tolerance"] > potency*-2)
+		processing_tray.mutation_controller["Light Tolerance"] = potency*-2
+	if (processing_tray.mutation_controller["Weed Tolerance"] > potency*-2)
+		processing_tray.mutation_controller["Weed Tolerance"] = potency*-2
+	if (processing_tray.mutation_controller["Toxin Tolerance"] > potency*-2)
+		processing_tray.mutation_controller["Toxin Tolerance"] = potency*-2
+
 /datum/chem_property/negative/pneumotoxic
 	name = PROPERTY_PNEUMOTOXIC
 	code = "PNT"
-	description = "Toxic substance which causes damage to connective tissue that forms the support structure (the interstitium) of the alveoli in the lungs."
+	description = "Toxic substance which causes damage to connective tissue that forms the support structure (the interstitium) of the alveoli in the lungs. Prevents growth speed and health from mutation in plants."
 	rarity = PROPERTY_UNCOMMON
 
 /datum/chem_property/negative/pneumotoxic/process(mob/living/M, potency = 1, delta_time)
@@ -402,10 +424,25 @@
 /datum/chem_property/negative/pneumotoxic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 
+//Applies mutation cancel onto hydrotray plants, prevents plant life, yield, grow times and repeat harvest mutation
+/datum/chem_property/negative/pneumotoxic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Endurance"] > potency*-2)
+		processing_tray.mutation_controller["Endurance"] = potency*-2
+	if (processing_tray.mutation_controller["Production"] > potency*-2)
+		processing_tray.mutation_controller["Production"] = potency*-2
+	if (processing_tray.mutation_controller["Lifespan"] > potency*-2)
+		processing_tray.mutation_controller["Lifespan"] = potency*-2
+	if (processing_tray.mutation_controller["Maturity"] > potency*-2)
+		processing_tray.mutation_controller["Maturity"] = potency*-2
+
+
 /datum/chem_property/negative/oculotoxic
 	name = PROPERTY_OCULOTOXIC
 	code = "OCT"
-	description = "Damages the photoreceptive cells in the eyes impairing neural transmissions to the brain, resulting in loss of sight or blindness."
+	description = "Damages the photoreceptive cells in the eyes impairing neural transmissions to the brain, resulting in loss of sight or blindness. Prevents potency from mutation in plants."
 	rarity = PROPERTY_UNCOMMON
 
 /datum/chem_property/negative/oculotoxic/process(mob/living/M, potency = 1, delta_time)
@@ -423,10 +460,22 @@
 /datum/chem_property/negative/oculotoxic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(POTENCY_MULTIPLIER_LOW * potency, BRAIN)
 
+//Applies mutation cancel onto hydrotray plants, prevents potency, glowing or flowers mutations
+/datum/chem_property/negative/oculotoxic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Potency"] > potency*-2)
+		processing_tray.mutation_controller["Potency"] = potency*-2
+	if (processing_tray.mutation_controller["Bioluminecence"] > potency*-2)
+		processing_tray.mutation_controller["Bioluminecence"] = potency*-2
+	if (processing_tray.mutation_controller["Flowers"] > potency*-2)
+		processing_tray.mutation_controller["Flowers"] = potency*-2
+
 /datum/chem_property/negative/cardiotoxic
 	name = PROPERTY_CARDIOTOXIC
 	code = "CDT"
-	description = "Attacks cardiomyocytes when passing through the heart in the bloodstream. This disrupts the cardiac cycle and can lead to cardiac arrest."
+	description = "Attacks cardiomyocytes when passing through the heart in the bloodstream. This disrupts the cardiac cycle and can lead to cardiac arrest. Prevents produced chemicals from mutation in plants."
 	rarity = PROPERTY_COMMON
 
 /datum/chem_property/negative/cardiotoxic/process(mob/living/M, potency = 1, delta_time)
@@ -441,10 +490,22 @@
 /datum/chem_property/negative/cardiotoxic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(POTENCY_MULTIPLIER_VHIGH * potency, OXY)
 
+//Applies mutation cancel onto hydrotray plants, prevents new chems from being added
+/datum/chem_property/negative/cardiotoxic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["New Chems"] > potency*-2)
+		processing_tray.mutation_controller["New Chems"] = potency*-2
+	if (processing_tray.mutation_controller["New Chems2"] > potency*-2)
+		processing_tray.mutation_controller["New Chems2"] = potency*-2
+	if (processing_tray.mutation_controller["New Chems3"] > potency*-2)
+		processing_tray.mutation_controller["New Chems3"] = potency*-2
+
 /datum/chem_property/negative/neurotoxic
 	name = PROPERTY_NEUROTOXIC
 	code = "NRT"
-	description = "Breaks down neurons causing widespread damage to the central nervous system and brain functions. Exposure may cause disorientation or unconsciousness to affected persons."
+	description = "Breaks down neurons causing widespread damage to the central nervous system and brain functions. Exposure may cause disorientation or unconsciousness to affected persons. Prevents species mutation in plants."
 	rarity = PROPERTY_COMMON
 	category = PROPERTY_TYPE_TOXICANT|PROPERTY_TYPE_STIMULANT
 	cost_penalty = FALSE
@@ -473,10 +534,18 @@
 		var/mob/living/carbon/xenomorph/xeno = M
 		xeno.AddComponent(/datum/component/status_effect/daze, volume * potency * POTENCY_MULTIPLIER_LOW, 30)
 
+//Applies mutation cancel onto hydrotray plants, prevents species mutation
+/datum/chem_property/negative/neurotoxic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Mutate Species"] > potency*-2)
+		processing_tray.mutation_controller["Mutate Species"] = potency*-2
+
 /datum/chem_property/negative/hypermetabolic
 	name = PROPERTY_HYPERMETABOLIC
 	code = "EMB"
-	description = "Takes less time for this chemical to metabolize, resulting in it being in the bloodstream for less time per unit."
+	description = "Takes less time for this chemical to metabolize, resulting in it being in the bloodstream for less time per unit. Accelerates plant growth."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_METABOLITE
 

--- a/code/modules/reagents/chemistry_properties/prop_neutral.dm
+++ b/code/modules/reagents/chemistry_properties/prop_neutral.dm
@@ -35,7 +35,7 @@
 /datum/chem_property/neutral/excreting
 	name = PROPERTY_EXCRETING
 	code = "EXT"
-	description = "Excretes all chemicals contained in the blood stream by using the kidneys to turn it into urine."
+	description = "Excretes all chemicals contained in the blood stream by using the kidneys to turn it into urine. Upregulates chemical production in plants."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_IRRITANT
 
@@ -46,15 +46,15 @@
 	. = ..()
 	if(!processing_tray.seed)
 		return
-	processing_tray.toxins += (potency*2)*volume
+	processing_tray.toxins += 1.5*(potency*2)*volume
 	processing_tray.weedlevel += 1*(potency*2)*volume
-	processing_tray.nutrilevel += -0.25*(potency*2)*volume
 	processing_tray.potency_counter += 5*(potency*2)*volume
 	if (processing_tray.potency_counter >= 100 && rand(0,potency*2) > 0)
 		var/turf/c_turf = get_turf(processing_tray)
 		processing_tray.seed = processing_tray.seed.diverge()
 		processing_tray.seed.potency += rand(1,potency*2)
-		c_turf.visible_message(SPAN_NOTICE("[processing_tray.seed.display_name] rustles as its branches bow"))
+		processing_tray.seed.nutrient_consumption += 0.3*(potency*2)
+		c_turf.visible_message(SPAN_NOTICE("\The [processing_tray.seed.display_name] rustles as its branches bow"))
 		processing_tray.potency_counter = 0
 
 /datum/chem_property/neutral/nutritious
@@ -362,7 +362,7 @@
 /datum/chem_property/neutral/fluffing
 	name = PROPERTY_FLUFFING
 	code = "FLF"
-	description = "Accelerates cell division in the hair follicles resulting in random and excessive hairgrowth."
+	description = "Accelerates cell division in the hair follicles resulting in random and excessive hairgrowth. Found to increase yeilds in plants."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_IRRITANT
 	value = 0
@@ -522,7 +522,7 @@
 /datum/chem_property/neutral/hypometabolic
 	name = PROPERTY_HYPOMETABOLIC
 	code = "OMB"
-	description = "Takes longer for this chemical to metabolize, resulting in it being in the bloodstream for more time per unit."
+	description = "Takes longer for this chemical to metabolize, resulting in it being in the bloodstream for more time per unit. Slows down metabolism of plants."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_METABOLITE
 	value = 2

--- a/code/modules/reagents/chemistry_properties/prop_positive.dm
+++ b/code/modules/reagents/chemistry_properties/prop_positive.dm
@@ -6,7 +6,7 @@
 /datum/chem_property/positive/antitoxic
 	name = PROPERTY_ANTITOXIC
 	code = "ATX"
-	description = "Absorbs and neutralizes toxic chemicals in the bloodstream and allowing them to be excreted safely."
+	description = "Absorbs and neutralizes toxic chemicals in the bloodstream and xylem sap, allowing them to be excreted safely."
 	rarity = PROPERTY_COMMON
 	starter = TRUE
 	value = 1
@@ -26,12 +26,12 @@
 	if(!processing_tray.seed)
 		return
 	if(processing_tray.toxins > 0)
-		processing_tray.toxins += -1*(potency*2)
+		processing_tray.toxins += -1.5*(potency*2)
 
 /datum/chem_property/positive/anticorrosive
 	name = PROPERTY_ANTICORROSIVE
 	code = "ACR"
-	description = "Accelerates cell division around corroded areas in order to replace the lost tissue. Excessive use can trigger apoptosis."
+	description = "Accelerates cell division around corroded areas in order to replace the lost tissue. Plant damage rapidly healed. Excessive use can trigger apoptosis."
 	rarity = PROPERTY_COMMON
 	starter = TRUE
 	value = 1
@@ -52,7 +52,7 @@
 	if(!processing_tray.seed)
 		return
 	if(processing_tray.toxins > 0)
-		processing_tray.toxins += -1*(potency*2)
+		processing_tray.plant_health += 0.75*(potency*2)
 
 /datum/chem_property/positive/neogenetic
 	name = PROPERTY_NEOGENETIC
@@ -290,7 +290,7 @@
 /datum/chem_property/positive/hepatopeutic
 	name = PROPERTY_HEPATOPEUTIC
 	code = "HPP"
-	description = "Treats deteriorated hepatocytes and damaged tissues in the liver, restoring organ functions."
+	description = "Treats deteriorated hepatocytes and damaged tissues in the liver, restoring organ functions. Forces some negative mutations in plants."
 	rarity = PROPERTY_UNCOMMON
 	value = 1
 
@@ -307,10 +307,20 @@
 /datum/chem_property/positive/hepatopeutic/process_critical(mob/living/M, potency = 1, delta_time)
 	M.apply_damage(2.5 * potency * delta_time, TOX)
 
+//Applies mutation enable onto hydrotray plants, negative affects like increasing consumption and lowering life
+/datum/chem_property/positive/hepatopeutic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Plant Cancer"] < 1)
+		processing_tray.mutation_controller["Plant Cancer"] = 1
+	if (processing_tray.mutation_controller["Gluttony"] < 1)
+		processing_tray.mutation_controller["Gluttony"] = 1
+
 /datum/chem_property/positive/nephropeutic
 	name = PROPERTY_NEPHROPEUTIC
 	code = "NPP"
-	description = "Heals damaged and deteriorated podocytes in the kidney, restoring organ functions."
+	description = "Heals damaged and deteriorated podocytes in the kidney, restoring organ functions. Forces mutation of the tolerance to light, weeds, and toxins in plants."
 	rarity = PROPERTY_UNCOMMON
 	value = 1
 
@@ -327,10 +337,22 @@
 /datum/chem_property/positive/nephropeutic/process_critical(mob/living/M, potency = 1, delta_time)
 	M.apply_damage(2.5 * potency * delta_time, TOX)
 
+//Applies mutation enable onto hydrotray plants, enables tolerance adjustment, parasitic and carnivorus
+/datum/chem_property/positive/nephropeutic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Light Tolerance"] < 1)
+		processing_tray.mutation_controller["Light Tolerance"] = 1
+	if (processing_tray.mutation_controller["Weed Tolerance"] < 1)
+		processing_tray.mutation_controller["Weed Tolerance"] = 1
+	if (processing_tray.mutation_controller["Toxin Tolerance"] < 1)
+		processing_tray.mutation_controller["Toxin Tolerance"] = 1
+
 /datum/chem_property/positive/pneumopeutic
 	name = PROPERTY_PNEUMOPEUTIC
 	code = "PNP"
-	description = "Mends the interstitium tissue of the alveoli restoring respiratory functions in the lungs."
+	description = "Mends the interstitium tissue of the alveoli restoring respiratory functions in the lungs. Forces mutation of growth speed and health in plants."
 	rarity = PROPERTY_UNCOMMON
 	value = 1
 
@@ -347,10 +369,24 @@
 /datum/chem_property/positive/pneumopeutic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(POTENCY_MULTIPLIER_VHIGH*potency, OXY)
 
+//Applies mutation enable onto hydrotray plants, enables plant life, yield, grow times and repeat harvest mutation
+/datum/chem_property/positive/pneumopeutic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Endurance"] < 1)
+		processing_tray.mutation_controller["Endurance"] = 1
+	if (processing_tray.mutation_controller["Production"] < 1)
+		processing_tray.mutation_controller["Production"] = 1
+	if (processing_tray.mutation_controller["Lifespan"] < 1)
+		processing_tray.mutation_controller["Lifespan"] = 1
+	if (processing_tray.mutation_controller["Maturity"] < 1)
+		processing_tray.mutation_controller["Maturity"] = 1
+
 /datum/chem_property/positive/oculopeutic
 	name = PROPERTY_OCULOPEUTIC
 	code = "OCP"
-	description = "Restores sensory capabilities of photoreceptive cells in the eyes returning lost vision."
+	description = "Restores sensory capabilities of photoreceptive cells in the eyes returning lost vision. Forces mutation of potency in plants."
 	rarity = PROPERTY_COMMON
 	value = 1
 
@@ -368,10 +404,22 @@
 	M.apply_damages(potency, potency, POTENCY_MULTIPLIER_HIGH * potency)
 	M.apply_damage(potency, BRAIN)
 
+//Applies mutation enable onto hydrotray plants, enables potency, glowing or flowers mutations
+/datum/chem_property/positive/oculopeutic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Potency"] < 1)
+		processing_tray.mutation_controller["Potency"] = 1
+	if(processing_tray.mutation_controller["Bioluminecence"] < 1)
+		processing_tray.mutation_controller["Bioluminecence"] = 1
+	if (processing_tray.mutation_controller["Flowers"] < 1)
+		processing_tray.mutation_controller["Flowers"] = 1
+
 /datum/chem_property/positive/cardiopeutic
 	name = PROPERTY_CARDIOPEUTIC
 	code = "CDP"
-	description = "Regenerates damaged cardiomyocytes and recovers a correct cardiac cycle and heart functionality."
+	description = "Regenerates damaged cardiomyocytes and recovers a correct cardiac cycle and heart functionality. Prevents forces mutation of produced chemicals in plants."
 	rarity = PROPERTY_UNCOMMON
 	value = 1
 
@@ -394,10 +442,22 @@
 
 	M.pain.apply_pain(PROPERTY_CARDIOPEUTIC_PAIN_CRITICAL)
 
+//Applies mutation cancel onto hydrotray plants, enables new chems from being added
+/datum/chem_property/positive/cardiopeutic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["New Chems"] < 1)
+		processing_tray.mutation_controller["New Chems"] = 1
+	if(processing_tray.mutation_controller["New Chems2"] < 1)
+		processing_tray.mutation_controller["New Chems2"] = 1
+	if (processing_tray.mutation_controller["New Chems3"] < 1)
+		processing_tray.mutation_controller["New Chems3"] = 1
+
 /datum/chem_property/positive/neuropeutic
 	name = PROPERTY_NEUROPEUTIC
 	code = "NRP"
-	description = "Rebuilds damaged and broken neurons in the central nervous system re-establishing brain functionality."
+	description = "Rebuilds damaged and broken neurons in the central nervous system re-establishing brain functionality. Forces species mutation in plants."
 	rarity = PROPERTY_COMMON
 
 /datum/chem_property/positive/neuropeutic/process(mob/living/M, potency = 1)
@@ -409,6 +469,14 @@
 /datum/chem_property/positive/neuropeutic/process_critical(mob/living/M, potency = 1)
 	M.apply_damage(POTENCY_MULTIPLIER_HIGH * potency, BRAIN)
 	M.adjust_effect(potency, STUN)
+
+//Applies mutation enable onto hydrotray plants, enables species mutation
+/datum/chem_property/positive/neuropeutic/reaction_hydro_tray(obj/structure/machinery/portable_atmospherics/hydroponics/processing_tray, potency, volume)
+	. = ..()
+	if(!processing_tray.seed)
+		return
+	if (processing_tray.mutation_controller["Mutate Species"] < 1)
+		processing_tray.mutation_controller["Mutate Species"] = 1
 
 /datum/chem_property/positive/bonemending
 	name = PROPERTY_BONEMENDING
@@ -865,7 +933,7 @@
 /datum/chem_property/positive/photosensitive
 	name = PROPERTY_PHOTOSENSITIVE
 	code = "PTS"
-	description = "Reacts with any amount of light. Can be useful to create light-sensitive objects. Not safe to administer."
+	description = "Reacts with any amount of light. Can be useful to create light-sensitive objects. Not safe to administer. Supercharges photosynthesis, treated plants able to be harvested repeatedly "
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_TOXICANT
 	max_level = 1
@@ -880,9 +948,9 @@
 		return
 	if(processing_tray.seed.harvest_repeat == 1)
 		return
-	processing_tray.weedlevel += 0.8*(10-(potency*2))*volume
-	processing_tray.nutrilevel += -0.6*(10-(potency*2))*volume
-	processing_tray.repeat_harvest_counter += 5*(potency*2)*volume
+	processing_tray.weedlevel += 0.25*volume
+	processing_tray.nutrilevel += -0.25*volume
+	processing_tray.repeat_harvest_counter += 10*volume
 	if (processing_tray.repeat_harvest_counter >= 100)
 		if (prob(50))
 			processing_tray.repeat_harvest_counter += -1*rand(20,50)
@@ -896,7 +964,7 @@
 /datum/chem_property/positive/crystallization
 	name = PROPERTY_CRYSTALLIZATION
 	code = "CRL"
-	description = "The chemical structure of the chemical forms itself in a lens. passing light wider, while also keeping focus. Not safe to administer"
+	description = "The chemical structure of the chemical forms itself in a lens. passing light wider, while also keeping focus. Not safe to administer. Hardens root structure of plants, improving survivability during repeat harvests."
 	rarity = PROPERTY_UNCOMMON
 	category = PROPERTY_TYPE_TOXICANT
 	max_level = 1
@@ -912,9 +980,9 @@
 		return
 	if(processing_tray.seed.harvest_repeat == 1)
 		return
-	processing_tray.weedlevel += 0.8*(10-(potency*2))*volume
-	processing_tray.nutrilevel += -0.8*(10-(potency*2))*volume
-	processing_tray.repeat_harvest_counter += 5*(potency*2)*volume
+	processing_tray.weedlevel += 0.25*volume
+	processing_tray.nutrilevel += -0.25*volume
+	processing_tray.repeat_harvest_counter += 10*volume
 	if (processing_tray.repeat_harvest_counter >= 100)
 		if (prob(50))
 			processing_tray.repeat_harvest_counter += -1*rand(20,50)
@@ -1029,7 +1097,7 @@
 /datum/chem_property/positive/aiding
 	name = PROPERTY_AIDING
 	code = "AID"
-	description = "Fixes genetic defects, disfigurments and disabilities."
+	description = "Fixes genetic defects, disfigurments, disabilities. In plants removes compounds modfying yield and mutation."
 	rarity = PROPERTY_DISABLED
 	category = PROPERTY_TYPE_MEDICINE
 	value = 1
@@ -1053,7 +1121,7 @@
 	if(!processing_tray.seed)
 		return
 	processing_tray?.mutation_mod += -4*(potency*2)*volume
-
+	processing_tray?.yield_mod += -4*(potency*2)*volume
 
 /datum/chem_property/positive/oxygenating
 	name = PROPERTY_OXYGENATING


### PR DESCRIPTION
Botany, Rebalancing to be more friendly and account for photosense and cystallizing being capped at 1. Changed botany related chem and xeno blood discriptions to succinctly state or hint for xeno bloods their use in botany. Added mutation controller allowing you to set what mutations you want a chance to roll. blocking or forcing species mutation! mutations only adding chems, or mutations never adding chems! Based off of the organ healing or damaging properties as they seem underused. Potency and species mutation controllers, neuro and oculo avaliable at round start too

